### PR TITLE
Refresh dependencies and drop Python 3.6 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pygments>=2.14.0;python_version<"3.7"
-pygments>=2.16.1;python_version>="3.7"
-tabcompleter>=1.2.1
-colorama>=0.4.5;platform_system=="Windows"
+pygments>=2.16.1
+tabcompleter>=1.3.0
+colorama>=0.4.6;platform_system=="Windows"

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ if sys.argv[-1] == "publish":
 
 setup(
     name="pdbp",
-    version="1.4.6",
+    version="1.5.0",
     description="pdbp (Pdb+): A drop-in replacement for pdb and pdbpp.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """*** pdbp (Pdb+) ***
 An advanced console debugger for Python.
 Can be used as a drop-in replacement for pdb and pdbpp.
-(Python 3.6+)"""
+(Python 3.7+)"""
 from setuptools import setup, find_packages  # noqa
 import os
 import sys
@@ -103,7 +103,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -120,12 +119,11 @@ setup(
         "Topic :: Software Development :: Testing",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
-        'pygments>=2.14.0;python_version<"3.7"',
-        'pygments>=2.16.1;python_version>="3.7"',
-        "tabcompleter>=1.2.1",
-        'colorama>=0.4.5;platform_system=="Windows"',
+        "pygments>=2.16.1",
+        "tabcompleter>=1.3.0",
+        'colorama>=0.4.6;platform_system=="Windows"',
     ],
     setup_requires=[],
     include_package_data=True,


### PR DESCRIPTION
## Refresh dependencies and drop Python 3.6 support
* [Refresh dependencies and drop Python 3.6 support](https://github.com/mdmintz/pdbp/commit/cc951ccd0e95703d054194a403be031b0c17f9f2)
--> This resolves https://github.com/mdmintz/pdbp/issues/54