### PR TITLE
Repair stack-trace frame indexing

### DIFF
--- a/src/pdbp.py
+++ b/src/pdbp.py
@@ -1199,13 +1199,19 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         else:
             stack_to_print = self.stack[-count:]
         try:
-            for frame_lineno in stack_to_print:
-                self.print_stack_entry(frame_lineno)
+            for frame_index, frame_lineno in enumerate(stack_to_print):
+                self.print_stack_entry(
+                    frame_lineno,
+                    frame_index=frame_index,
+                )
         except KeyboardInterrupt:
             pass
 
     def print_stack_entry(
-        self, frame_lineno, prompt_prefix=pdb.line_prefix, frame_index=None
+        self,
+        frame_lineno,
+        prompt_prefix=pdb.line_prefix,
+        frame_index=None,
     ):
         if self.sticky:
             return


### PR DESCRIPTION
A regression from 52ee795, without this the output from `pdbp.Pdbp.print_stack_trace()` will show the same `frame_index: int` value (the current one at the time of interaction).

---

Prior to this fix there was a regression which causes all stack frames to print the same index,

<img width="1919" height="1341" alt="pdbp_borked_py314patch_2025-11-20T12:20:09,193288223-05:00" src="https://github.com/user-attachments/assets/2a808583-29dc-4969-8e54-e5a69d080168" />

After this (reversion) commit, everything goes back to normal 😎 